### PR TITLE
Remove the build over PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
 
 before_script:


### PR DESCRIPTION
Some parts of the code are not compatible with PHP 5.3. For example, some closures use `$this`are the use of traits.
