### PR TITLE
Allowing null instead of a logger.

### DIFF
--- a/src/Scrutinizer/Logger/LoggableProcess.php
+++ b/src/Scrutinizer/Logger/LoggableProcess.php
@@ -10,7 +10,7 @@ class LoggableProcess extends Process
     /** @var LoggerInterface */
     private $logger;
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
If there is a null === handling, null should be allowed to be a argument.
