### PR TITLE
string type was not listed..

### DIFF
--- a/doc/tools/php/php-analyzer/guides/annotating_code.rst
+++ b/doc/tools/php/php-analyzer/guides/annotating_code.rst
@@ -52,6 +52,8 @@ This is a reference of which types are supported in doc comments.
 +---------------------------------+-----------------------------------------------+
 | ``float``, or ``double``        | Value is a float.                             |
 +---------------------------------+-----------------------------------------------+
+| ``string``                      | Value is a string.                            |
++---------------------------------+-----------------------------------------------+
 | ``null``                        | Value is null. This only makes sense in       |
 |                                 | combination with another type, e.g.           |
 |                                 | ``string|null``.                              |


### PR DESCRIPTION
string type was not listed, even though it is used in the examples of false and null
