### PR TITLE
Preserve file relative path & name during PHP_CodeSniffer analyzer run

### DIFF
--- a/src/Scrutinizer/Analyzer/Php/CsAnalyzer.php
+++ b/src/Scrutinizer/Analyzer/Php/CsAnalyzer.php
@@ -1226,7 +1226,9 @@ class CsAnalyzer extends AbstractFileAnalyzer
         $outputFile = tempnam(sys_get_temp_dir(), 'phpcs');
         $cmd .= ' --report-checkstyle='.escapeshellarg($outputFile);
 
-        $inputFile = tempnam(sys_get_temp_dir(), 'phpcs');
+        $tempFolder = sys_get_temp_dir() . '/' . uniqid('phpcs', true);
+        $inputFile = $tempFolder . '/' . $file->getPath();
+        mkdir(dirname($inputFile), 0777, true);
         file_put_contents($inputFile, $file->getContent());
         $cmd .= ' '.escapeshellarg($inputFile);
 
@@ -1238,6 +1240,7 @@ class CsAnalyzer extends AbstractFileAnalyzer
 
         unlink($outputFile);
         unlink($inputFile);
+        shell_exec('rm -Rf ' . $tempFolder);
         if (null !== $standardsDir) {
             unlink($standardsDir.'/ruleset.xml');
             rmdir($standardsDir);

--- a/tests/Scrutinizer/Tests/Analyzer/Php/CsAnalyzer/custom_ruleset_with_per_sniff_file_exclude.test
+++ b/tests/Scrutinizer/Tests/Analyzer/Php/CsAnalyzer/custom_ruleset_with_per_sniff_file_exclude.test
@@ -1,0 +1,69 @@
+<?php
+
+class Foo
+{
+    public function foo() {
+        echo 'foo';
+    }
+}
+
+-- FILENAME --
+Foo.php
+
+-- FILE: phpcs/ruleset.xml --
+<?xml version="1.0"?>
+<ruleset name="NOS">
+    <description>Coding standard for Novius-OS</description>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>fuel-core/*</exclude-pattern>
+    <exclude-pattern>packages/*</exclude-pattern>
+    <exclude-pattern>static/*</exclude-pattern>
+    <exclude-pattern>hooks/*</exclude-pattern>
+    <exclude-pattern>logs/*</exclude-pattern>
+    <exclude-pattern>ci/*</exclude-pattern>
+    <exclude-pattern>framework/vendor/*</exclude-pattern>
+    <exclude-pattern>local/config/*</exclude-pattern>
+    <exclude-pattern>local/metadata/*</exclude-pattern>
+
+    <!-- Include the whole PSR-2 standard -->
+    <rule ref="PSR2">
+        <exclude name="Squiz.Classes.ValidClassName"/>
+        <exclude name="Generic.NamingConventions.CamelCapsFunctionName"/>
+        <exclude name="PEAR.Functions.FunctionCallSignature"/>
+        <exclude name="PSR1.Files.SideEffects"/>
+        <exclude name="PSR1.Classes.ClassDeclaration"/>
+    </rule>
+
+    <!-- Classes -->
+    <rule ref="PEAR.Classes.ClassDeclaration"/>
+    <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
+
+
+    <!-- Files -->
+
+    <!-- Formatting -->
+    <rule ref="Generic.Formatting.SpaceAfterCast"/>
+
+    <!-- Functions -->
+    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman">
+        <exclude-pattern>Foo.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR2.Namespaces.NamespaceDeclaration"/>
+
+
+
+    <rule ref="Squiz.Scope.MemberVarScope"/>
+
+</ruleset>
+
+-- CONFIG --
+tools:
+    php_code_sniffer:
+        config:
+            standard: phpcs/ruleset.xml
+
+-- COMMENTS --
+Line 5: Opening brace should be on a new line
+Line 8: Expected 1 newline at end of file; 0 found


### PR DESCRIPTION
1. I'm not sure it that is covered by tests at 100%, because the `$file->getPath()` always resulted in `Foo.php` without relative path. I have added a test however, that will exclude one sniff based for a `Foo.php` file. This way if that breaks at some point, then we'll have failing test.
2. I've used `shell_exec` to recursively remove a directory and because of it won't work on Windows.

Closes #201
